### PR TITLE
fix: use correct data-bs-* names for navbar

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@
       <!-- Nav Bar -->
       <nav class="navbar navbar-expand-lg navbar-dark">
         <a class="navbar-brand" href="">tindog</a>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#giveItATry" aria-controls="giveItATry" aria-expanded="false" aria-label="Toggle navigation">
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#giveItATry" aria-controls="giveItATry" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
         </button>
         <div class="collapse navbar-collapse" id="giveItATry">


### PR DESCRIPTION
The `data-*` names were moved to `data-bs-*` names in Bootstrap 5.x

Signed-off-by: Mike Fiedler <miketheman@gmail.com>